### PR TITLE
Connect users to a given room and set their names

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,11 @@
   :url "http://example.com/FIXME"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url "https://www.eclipse.org/legal/epl-2.0/"}
-  :dependencies [[org.clojure/clojure "1.10.3"]]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [org.clojure/data.json "2.4.0"]
+                 [compojure "1.6.2"]
+                 [aleph "0.4.6"]]
+
   :main ^:skip-aot racegex.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all

--- a/src/racegex/core.clj
+++ b/src/racegex/core.clj
@@ -1,7 +1,9 @@
+(require '[racegex.websocket])
+
 (ns racegex.core
   (:gen-class))
 
 (defn -main
-  "I don't do a whole lot ... yet."
+  "Starts the server"
   [& args]
-  (println "Hello, World!"))
+  (racegex.websocket/serve))

--- a/src/racegex/websocket.clj
+++ b/src/racegex/websocket.clj
@@ -1,0 +1,67 @@
+(ns racegex.websocket
+  (:require [aleph.http :as http]
+            [compojure.core :as compojure :refer [GET]]
+            [compojure.route :as route]
+            [manifold.bus :as bus]
+            [manifold.deferred :as d]
+            [manifold.stream :as s]
+            [ring.middleware.params :as params]))
+
+(def non-websocket-request
+  {:status 400
+   :headers {"content-type" "application/text"}
+   :body "Expected a websocket request."})
+
+
+(defn echo-handler
+  [req]
+  (->
+   (d/let-flow [socket (http/websocket-connection req)]
+               (s/connect socket socket))
+   (d/catch
+    (fn [_]
+      non-websocket-request))))
+
+(def chatrooms (bus/event-bus))
+
+(defn chat-handler
+  [req]
+  (d/let-flow [conn (d/catch
+                     (http/websocket-connection req)
+                     (fn [_] nil))]
+              (if-not conn
+      ;; if it wasn't a valid websocket handshake, return an error
+                non-websocket-request
+      ;; otherwise, take the first two messages, which give us the chatroom and name
+                ((d/let-flow [room (s/take! conn)
+                              name (s/take! conn)]
+      ;; take all messages from the chatroom, and feed them to the client
+                             (s/connect
+                              (bus/subscribe chatrooms room)
+                              conn)
+      ;; take all messages from the client, and publish it to the room
+                             (s/consume
+                              #(bus/publish! chatrooms room %)
+                              (->> conn
+                                   (s/map #(str %))
+                                   (s/buffer 100)))
+      ;; Compojure expects some sort of HTTP response, so just give it `nil`
+                             nil)))))
+
+(def handler
+  (params/wrap-params
+   (compojure/routes
+    (GET "/echo" [] echo-handler)
+    ;; FIXME: We should decide if we want this route ("/") or another one
+    (GET "/" [] chat-handler)
+    (route/not-found "No such page."))))
+
+
+
+(defn serve []
+  (http/start-server handler
+;; FIXME: We should decide the port to use
+                     {:port 5000}))
+
+
+

--- a/src/racegex/websocket.clj
+++ b/src/racegex/websocket.clj
@@ -33,20 +33,20 @@
       ;; if it wasn't a valid websocket handshake, return an error
                 non-websocket-request
       ;; otherwise, take the first two messages, which give us the chatroom and name
-                ((d/let-flow [room (s/take! conn)
-                              name (s/take! conn)]
-      ;; take all messages from the chatroom, and feed them to the client
-                             (s/connect
-                              (bus/subscribe chatrooms room)
-                              conn)
-      ;; take all messages from the client, and publish it to the room
-                             (s/consume
-                              #(bus/publish! chatrooms room %)
-                              (->> conn
-                                   (s/map #(str %))
-                                   (s/buffer 100)))
-      ;; Compojure expects some sort of HTTP response, so just give it `nil`
-                             nil)))))
+                (d/let-flow [room (s/take! conn)
+                             name (s/take! conn)]
+        ;; take all messages from the chatroom, and feed them to the client
+                            (s/connect
+                             (bus/subscribe chatrooms room)
+                             conn)
+        ;; take all messages from the client, prepend the name, and publish it to the room
+                            (s/consume
+                             #(bus/publish! chatrooms room %)
+                             (->> conn
+                                  (s/map #(str %))
+                                  (s/buffer 100)))
+        ;; Compojure expects some sort of HTTP response, so just give it `nil`
+                            nil))))
 
 (def handler
   (params/wrap-params


### PR DESCRIPTION
### Summary

With this change, we can run `lein run` and it'll start the websocket server on `localhost:5000`. It'll expect two messages after joining, the first one contains the room name, and the second one contains the racer name.

After that, every consequent message gets broadcasted to the whole room.