### PR TITLE
Implement join request handling

### DIFF
--- a/src/racegex/websocket.clj
+++ b/src/racegex/websocket.clj
@@ -5,60 +5,64 @@
             [manifold.bus :as bus]
             [manifold.deferred :as d]
             [manifold.stream :as s]
-            [ring.middleware.params :as params]))
+            [ring.middleware.params :as params]
+	    [clojure.data.json :as json]))
 
 (def non-websocket-request
   {:status 400
    :headers {"content-type" "application/text"}
    :body "Expected a websocket request."})
 
+(def users-per-room (atom {}))
 
-(defn echo-handler
-  [req]
-  (->
-   (d/let-flow [socket (http/websocket-connection req)]
-               (s/connect socket socket))
-   (d/catch
-    (fn [_]
-      non-websocket-request))))
+(defn insert-user
+  [users room user]
+    (let
+      [room-users (find users room)]
+      (if room-users
+        (assoc users room (assoc (val room-users) user "online"))
+	(assoc users room {user "online"}))))
 
-(def chatrooms (bus/event-bus))
+(def rooms (bus/event-bus))
 
-(defn chat-handler
-  [req]
-  (d/let-flow [conn (d/catch
-                     (http/websocket-connection req)
+(defn join-handler
+  [socket room user]
+    (println "got a user " room " " user)
+    (swap! users-per-room insert-user room user)
+    (s/connect
+      (bus/subscribe rooms room)
+      socket)
+    (bus/publish! rooms room
+      (json/write-str {:type "room-update" :users (get @users-per-room room)})))
+
+(defn new-connection-handler
+  [request]
+  (d/let-flow [socket (d/catch
+                     (http/websocket-connection request)
                      (fn [_] nil))]
-              (if-not conn
-      ;; if it wasn't a valid websocket handshake, return an error
+              (if-not socket
                 non-websocket-request
-      ;; otherwise, take the first two messages, which give us the chatroom and name
-                (d/let-flow [room (s/take! conn)
-                             name (s/take! conn)]
-        ;; take all messages from the chatroom, and feed them to the client
-                            (s/connect
-                             (bus/subscribe chatrooms room)
-                             conn)
-        ;; take all messages from the client, prepend the name, and publish it to the room
-                            (s/consume
-                             #(bus/publish! chatrooms room %)
-                             (->> conn
-                                  (s/map #(str %))
-                                  (s/buffer 100)))
-        ;; Compojure expects some sort of HTTP response, so just give it `nil`
-                            nil))))
+                (d/let-flow [message-str (s/take! socket)]
+		  (let [message (json/read-str message-str :key-fn keyword)]
+		   (println message)
+		    (if (= (get message :type) "join")
+		      (let
+		        [room (get message :room)
+		         user (get message :user)]
+	                (join-handler socket room user))
+		      nil))))))
 
 (def handler
   (params/wrap-params
    (compojure/routes
-    (GET "/echo" [] echo-handler)
     ;; FIXME: We should decide if we want this route ("/") or another one
-    (GET "/" [] chat-handler)
+    (GET "/" [] new-connection-handler)
     (route/not-found "No such page."))))
 
 
 
 (defn serve []
+  (println (json/read-str "{\"test\": 10}" :key-fn keyword))
   (http/start-server handler
 ;; FIXME: We should decide the port to use
                      {:port 5000}))


### PR DESCRIPTION
New websocket connections can now send as their first message a join
request. Every user in the room they requested to join (including
them) will then receive an update on the state of the room.

Solves #16.